### PR TITLE
fix:ユーザー登録の修正

### DIFF
--- a/app/javascript/packs/password_toggle.js
+++ b/app/javascript/packs/password_toggle.js
@@ -1,0 +1,8 @@
+function togglePasswordVisibility() {
+  const passwordField = document.getElementById("password_field");
+  if (passwordField.type === "password") {
+    passwordField.type = "text";
+  } else {
+    passwordField.type = "password";
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  enum role: { general: 0, admin: 1 } # 役割の定義
+
+  validates :name, presence: true, length: { in: 1..20 }
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Forgot your password?</h2>
+<h2><%= t('.title') %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit t('.send_me_reset_password_instructions') %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,59 @@
-<h2>Sign up</h2>
+<h2><%= t('.title') %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :name %><br>
-    <%= f.text_field :name, autofocus: true %>
-  </div>
-
-  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %><br />
     <%= f.label :email %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em>(<%= @minimum_password_length %> <%= t('.characters_minimum') %>)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, autocomplete: "new-password", id: "password_field" %>
+    <div>
+      <%= check_box_tag 'show_password', '1', false, onclick: 'togglePasswordVisibility()' %>
+      <%= label_tag 'show_password', t('devise.registrations.new.show_password') %>
+    </div>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", id: "password_confirmation_field" %>
+    <div>
+      <%= check_box_tag t('.show_password_confirmation'), '1', false, onclick: 'togglePasswordConfirmationVisibility()' %>
+      <%= label_tag 'show_password_confirmation', t('.show_password_confirmation') %>
+    </div>
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit t('.sign_up') %>
   </div>
 <% end %>
+
+<script>
+function togglePasswordVisibility() {
+  const passwordField = document.getElementById("password_field");
+  if (passwordField.type === "password") {
+    passwordField.type = "text";
+  } else {
+    passwordField.type = "password";
+  }
+}
+
+function togglePasswordConfirmationVisibility() {
+  const passwordConfirmationField = document.getElementById("password_confirmation_field");
+  if (passwordConfirmationField.type === "password") {
+    passwordConfirmationField.type = "text";
+  } else {
+    passwordConfirmationField.type = "password";
+  }
+}
+</script>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Log in</h2>
+<h2><%= t('.title') %></h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
@@ -7,8 +7,15 @@
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> <%= t('.characters_minimum') %>)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password", id: "password_field" %>
+    <div>
+      <%= check_box_tag 'show_password', '1', false, onclick: 'togglePasswordVisibility()' %>
+      <%= label_tag 'show_password', t('devise.registrations.new.show_password') %>
+    </div>
   </div>
 
   <% if devise_mapping.rememberable? %>
@@ -19,8 +26,28 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit t('.sign_in') %>
   </div>
 <% end %>
+
+<script>
+function togglePasswordVisibility() {
+  const passwordField = document.getElementById("password_field");
+  if (passwordField.type === "password") {
+    passwordField.type = "text";
+  } else {
+    passwordField.type = "password";
+  }
+}
+
+function togglePasswordConfirmationVisibility() {
+  const passwordConfirmationField = document.getElementById("password_confirmation_field");
+  if (passwordConfirmationField.type === "password") {
+    passwordConfirmationField.type = "text";
+  } else {
+    passwordConfirmationField.type = "password";
+  }
+}
+</script>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('.sign_in'), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to t('.sign_up'), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t('.forgot_your_password'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -2,143 +2,94 @@ ja:
   activerecord:
     attributes:
       user:
-        confirmation_sent_at: パスワード確認送信時刻
-        confirmation_token: パスワード確認用トークン
-        confirmed_at: パスワード確認時刻
-        created_at: 作成日
-        current_password: 現在のパスワード
-        current_sign_in_at: 現在のログイン時刻
-        current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
-        name: ユーザーネーム
-        encrypted_password: 暗号化パスワード
-        failed_attempts: 失敗したログイン試行回数
-        last_sign_in_at: 最終ログイン時刻
-        last_sign_in_ip: 最終ログインIPアドレス
-        locked_at: ロック時刻
-        password: パスワード
-        password_confirmation: パスワード（確認用）
-        remember_created_at: ログイン記憶時刻
-        remember_me: ログインを記憶する
-        reset_password_sent_at: パスワードリセット送信時刻
-        reset_password_token: パスワードリセット用トークン
-        sign_in_count: ログイン回数
-        unconfirmed_email: 未確認Eメール
-        unlock_token: ロック解除用トークン
-        updated_at: 更新日
+        current_password: "現在のパスワード"
+        name: "ユーザーネーム"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "ログインを記憶"
     models:
-      user: ユーザー
+      user: "ユーザ"
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "メールアドレスを入力してください"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "メールアドレスの形式が正しくありません"
+              taken: "このメールアドレスは既に使用されています"
+            name:
+              blank: "ユーザーネームを入力してください"
+              too_short: "ユーザーネームは%{count}文字以上で入力してください"
+              too_long: "ユーザーネームは%{count}文字以下に設定して下さい。"
+            password:
+              blank: "パスワードを入力してください"
+              too_short: "パスワードは%{count}文字以上で入力してください"
+            password_confirmation:
+              confirmation: "パスワード確認が一致しません"
   devise:
     confirmations:
-      confirmed: メールアドレスが確認できました。
       new:
-        resend_confirmation_instructions: アカウント確認メール再送
-      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
-    failure:
-      already_authenticated: すでにログインしています。
-      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
-      invalid: "%{authentication_keys}またはパスワードが違います。"
-      last_attempt: もう一回誤るとアカウントがロックされます。
-      locked: アカウントはロックされています。
-      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
-      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: ログインもしくはアカウント登録してください。
-      unconfirmed: メールアドレスの本人確認が必要です。
+        resend_confirmation_instructions: "アカウント確認メール再送"
     mailer:
       confirmation_instructions:
-        action: メールアドレスの確認
-        greeting: "%{recipient}様"
-        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
-      email_changed:
-        greeting: こんにちは、%{recipient}様。
-        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
-        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
-        subject: メール変更完了
-      password_change:
-        greeting: "%{recipient}様"
-        message: パスワードが再設定されました。
-        subject: パスワードの変更について
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
       reset_password_instructions:
-        action: パスワード変更
-        greeting: "%{recipient}様"
-        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
-        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
-        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
-        subject: パスワードの再設定について
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
       unlock_instructions:
-        action: アカウントのロック解除
-        greeting: "%{recipient}様"
-        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
-        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
-        subject: アカウントのロック解除について
-    omniauth_callbacks:
-      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
-      success: "%{kind} アカウントによる認証に成功しました。"
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
     passwords:
       edit:
-        change_my_password: パスワードを変更する
-        change_your_password: パスワードを変更
-        confirm_new_password: 確認用新しいパスワード
-        new_password: 新しいパスワード
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
       new:
-        forgot_your_password: パスワードを忘れましたか？
-        send_me_reset_password_instructions: パスワードの再設定方法を送信する
-      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
-      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
-      updated: パスワードが正しく変更されました。
-      updated_not_active: パスワードが正しく変更されました。
+        title: "パスワード再設定"
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
     registrations:
-      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        are_you_sure: 本当によろしいですか？
-        cancel_my_account: アカウント削除
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
-        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
         title: "%{resource}編集"
-        unhappy: 気に入りません
-        update: 更新
-        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
       new:
-        sign_up: アカウント登録
-      signed_up: アカウント登録が完了しました。
-      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
-      signed_up_but_locked: アカウントがロックされているためログインできません。
-      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
-      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
-      updated: アカウント情報を変更しました。
-      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+        title: "新規登録"
+        sign_up: "アカウント登録"
+        show_password: "パスワードを見る"
+        show_password_confirmation: "確認用のパスワードを見る"
+        characters_minimum: "文字以上"
     sessions:
-      already_signed_out: 既にログアウト済みです。
       new:
-        sign_in: ログイン
-      signed_in: ログインしました。
-      signed_out: ログアウトしました。
+        title: "ログイン"
+        sign_in: "ログイン"
+        show_password_confirmation: "確認用のパスワードを見る"
     shared:
       links:
-        back: 戻る
-        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
-        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
-        forgot_your_password: パスワードを忘れましたか？
-        sign_in: ログイン
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password:  "パスワードをお忘れですか？"
+        sign_in: "ログインページ"
         sign_in_with_provider: "%{provider}でログイン"
-        sign_up: アカウント登録
-      minimum_password_length: "（%{count}字以上）"
+        sign_up: "アカウントを登録する"
     unlocks:
       new:
-        resend_unlock_instructions: アカウントのロック解除方法を再送する
-      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
-      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
-      unlocked: アカウントをロック解除しました。
-  errors:
-    messages:
-      already_confirmed: は既に登録済みです。ログインしてください。
-      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
-      expired: の有効期限が切れました。新しくリクエストしてください。
-      not_found: は見つかりませんでした。
-      not_locked: はロックされていません。
-      not_saved:
-        one: エラーが発生したため %{resource} は保存されませんでした。
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        title: "アカウントロック解除"
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/db/migrate/20241217053427_add_roll_to_users.rb
+++ b/db/migrate/20241217053427_add_roll_to_users.rb
@@ -1,0 +1,5 @@
+class AddRollToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_070809) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_17_053427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_070809) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要

- usersテーブルにroleカラムを追加

- 日本語化の修正
- チェックボックによるパスワードの可視化

## 実装内容
- [x] roleカラムを追加しgeneralとadminを設定
``` ruby
enum role: { general: 0, admin: 1 }
```

- [x] `config/locales/devise.views.ja.yml` を編集しviewに反映
- [x] パスワード可視化の実装
`app/javascript/packs/password_toggle.js` を追加・追記しviewに反映
``` javascript
function togglePasswordVisibility() {
  const passwordField = document.getElementById("password_field");
  if (passwordField.type === "password") {
    passwordField.type = "text";
  } else {
    passwordField.type = "password";
  }
}
```

 
## 確認方法
`fix_devise` ブランチでデプロイしサイトを確認しました。

## 関連Issue
なし