### PR TITLE
Feature/brands search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -4,4 +4,9 @@ class BrandsController < ApplicationController
                         .order("brands.id ASC")
                         .pluck("brands.name", "foods.name")
   end
+
+  def foods
+    @foods = Food.where(brand_id: params[:id]) # メーカーに関連するフードを取得
+    render json: @foods # フード情報をJSON形式で返す
+  end
 end

--- a/app/controllers/feeding_calculation_controller.rb
+++ b/app/controllers/feeding_calculation_controller.rb
@@ -2,6 +2,7 @@ class FeedingCalculationController < ApplicationController
   before_action :authenticate_user!, only: [ :save ]
 
   def new
+    @brand = Brand.all
     @foods = Food.all
   end
 
@@ -10,6 +11,7 @@ class FeedingCalculationController < ApplicationController
       redirect_to root_path and return
     end
     # フードと体重の取得
+    brand = Brand.find(params[:brand_id])
     food = Food.find(params[:food_id])
     weight = params[:weight].to_f
 
@@ -21,21 +23,24 @@ class FeedingCalculationController < ApplicationController
 
     # 結果を表示 (保存はしない)
     @result = {
+      brand_id: brand.id,
       food_id: food.id,
       weight: weight,
       daily_amount: daily_amount.round(2),
       calories: rer.round(2)
     }
 
+    brand = Brand.find(@result[:brand_id])
     food = Food.find(@result[:food_id])
+    @result[:brand_name] = brand.name
     @result[:food_name] = food.name  # foodの名前を追加
 
     render :result
   end
 
   def save
-    Rails.logger.debug("Food ID: #{params[:food_id]}")
     # ログインユーザーのみ保存
+    brand = Brand.find(params[:brand_id])
     food = Food.find(params[:food_id])
     weight = params[:weight].to_f
     # cat_name = params[:cat_name]
@@ -44,6 +49,7 @@ class FeedingCalculationController < ApplicationController
     daily_amount = (rer / food.calories_per_gram.to_f).round
 
     @result = {
+      brand_id: brand.id,
       food_id: food.id,
       weight: weight,
       daily_amount: daily_amount.round(2),
@@ -58,7 +64,8 @@ class FeedingCalculationController < ApplicationController
     FeedingCalculation.create!(
       user: current_user,
       cat: cat,
-      main_food_id: food.name,
+      brand_id: brand.id,
+      main_food_id: food.id,
       cat_id: cat.id,
       main_food_id: food.id,
       main_food_amount: daily_amount,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./packs/brand_food_filter";
+

--- a/app/javascript/packs/brand_food_filter.js
+++ b/app/javascript/packs/brand_food_filter.js
@@ -1,0 +1,30 @@
+document.addEventListener("turbo:load", () => {
+  const brandSelect = document.getElementById("brand_select");
+  const foodSelect = document.getElementById("food_select");
+
+  if (brandSelect && foodSelect) {
+    brandSelect.addEventListener("change", (event) => {
+      const brandId = event.target.value;
+
+      // プルダウンをリセットして「フードを選択」を追加
+      foodSelect.innerHTML = "<option value=''>フードを選択</option>";
+
+      if (brandId) {
+        fetch(`/brands/${brandId}/foods`)
+          .then((response) => response.json())
+          .then((foods) => {
+            // フードのオプションを追加
+            foods.forEach((food) => {
+              const option = document.createElement("option");
+              option.value = food.id;
+              option.textContent = food.name;
+              foodSelect.appendChild(option);
+            });
+          })
+          .catch((error) => {
+            console.error("Error fetching foods:", error);
+          });
+      }
+    });
+  }
+});

--- a/app/models/feeding_calculation.rb
+++ b/app/models/feeding_calculation.rb
@@ -1,6 +1,7 @@
 class FeedingCalculation < ApplicationRecord
   belongs_to :user, optional: true # 未ログイン時はユーザーがいないため optional: true
   belongs_to :cat, optional: true # 未ログイン時は猫の情報を保存しないため optional: true
+  belongs_to :brand, optional: true
   belongs_to :main_food, class_name: "Food", foreign_key: "main_food_id", optional: true
   belongs_to :sub_food, class_name: "Food", foreign_key: "sub_food_id", optional: true
 end

--- a/app/views/feeding_calculation/new.html.erb
+++ b/app/views/feeding_calculation/new.html.erb
@@ -1,9 +1,14 @@
-<h2 class="text-center mb-6 text-2xl" >1日の給与量を計算する</h2>
+<h2 class="text-center mb-6 text-2xl">1日の給与量を計算する</h2>
 <div class="flex justify-center">
   <%= form_with url: calculate_feeding_calculation_index_path, method: :post, local: true, data: { turbo: false } do |form| %>
     <div class="text-xl mb-6">
+      <%= form.label :brand_id, "メーカーを選択" %>
+      <%= select_tag :brand_id, options_from_collection_for_select(Brand.all, :id, :name), prompt: "メーカーを選択", id: "brand_select" %>
+    </div>
+
+    <div class="text-xl mb-6">
       <%= form.label :food_id, "フードを選択" %>
-      <%= form.collection_select :food_id, @foods, :id, :name %>
+      <%= select_tag :food_id, "", prompt: "フードを選択", id: "food_select", name: "food_id" %>
     </div>
 
     <div class="text-xl mb-6 flex items-center">

--- a/app/views/feeding_calculation/result.html.erb
+++ b/app/views/feeding_calculation/result.html.erb
@@ -1,6 +1,7 @@
 <h2 class="text-center mb-6 text-2xl" >計算結果</h2>
 <div class="flex justify-center mb-12">
   <div class="text-left space-y-4">
+    <p class="text-xl mb-6 ">メーカー名: <strong><%= @result[:brand_name] %></strong></p>
     <p class="text-xl mb-6 ">フード名: <strong><%= @result[:food_name] %></strong></p>
     <p class="text-xl mb-6 ">体重: <strong><%= @result[:weight] %></strong> kg</p>
     <p class="text-xl mb-6 ">1日の必要給与量: <strong><%= @result[:daily_amount] %></strong> g</p>
@@ -11,11 +12,12 @@
 <div class="flex justify-center">
   <div class="text-xl mb-6">
     <%= form_with url: save_feeding_calculation_index_path, method: :post, local: true do |f| %>
+      <%= f.hidden_field :brand_id, value: @result[:brand_id] %>
       <%= f.hidden_field :food_id, value: @result[:food_id] %>
       <%= f.hidden_field :weight, value: @result[:weight] %>
       <button type="submit" class="btn btn-wide text-xl bg-pink-200 text-orange-700 hover:bg-pink-100">マイページに保存する</button>
     <% end %>
   </div>
 
-  <%= link_to "再計算する", new_feeding_calculation_path, class: "btn btn-wide text-xl bg-emerald-200 text-orange-700 hover:bg-emerald-100" %>
+  <%= link_to "再計算する", '/', class: "btn btn-wide text-xl bg-emerald-200 text-orange-700 hover:bg-emerald-100" %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,6 +4,7 @@
 
   <% if @last_calculation.present? %>
     <div class="bg-white shadow-md rounded-lg p-5 flex flex-col items-center">
+      <p class="text-lg">前回選択したメーカー: <span class="font-semibold"><%= @last_calculation.brand.name %></span></p>
       <p class="text-lg">前回選択したフード: <span class="font-semibold"><%= @last_calculation.main_food.name %></span></p>
       <p class="text-lg">体重: <span class="font-semibold"><%= @last_calculation.cat.weight %></span> kg</p>
       <p class="text-lg">合計カロリー: <span class="font-semibold"><%= @last_calculation.total_daily_calories %></span> kcal</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :brands, only: [ :index, :show ]
-
+  resources :brands, only: [ :index, :show ] do
+    member do
+      get :foods # /brands/:id/foods に対応
+    end
+  end
   # Defines the root path route ("/")
   # root "posts#index"
   root "feeding_calculation#new"

--- a/db/migrate/20250108081253_add_brand_to_feeding_calculations.rb
+++ b/db/migrate/20250108081253_add_brand_to_feeding_calculations.rb
@@ -1,5 +1,5 @@
 class AddBrandToFeedingCalculations < ActiveRecord::Migration[7.2]
   def change
-    add_reference :feeding_calculations, :brand, null: false, foreign_key: true
+    add_reference :feeding_calculations, :brand, null: true, foreign_key: true
   end
 end

--- a/db/migrate/20250108081253_add_brand_to_feeding_calculations.rb
+++ b/db/migrate/20250108081253_add_brand_to_feeding_calculations.rb
@@ -1,0 +1,5 @@
+class AddBrandToFeedingCalculations < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :feeding_calculations, :brand, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_081253) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.bigint "brand_id", null: false
+    t.bigint "brand_id"
     t.index ["brand_id"], name: "index_feeding_calculations_on_brand_id"
     t.index ["cat_id"], name: "index_feeding_calculations_on_cat_id"
     t.index ["main_food_id"], name: "index_feeding_calculations_on_main_food_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_29_192456) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_08_081253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_29_192456) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.bigint "brand_id", null: false
+    t.index ["brand_id"], name: "index_feeding_calculations_on_brand_id"
     t.index ["cat_id"], name: "index_feeding_calculations_on_cat_id"
     t.index ["main_food_id"], name: "index_feeding_calculations_on_main_food_id"
     t.index ["sub_food_id"], name: "index_feeding_calculations_on_sub_food_id"
@@ -92,6 +94,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_29_192456) do
   end
 
   add_foreign_key "cats", "users"
+  add_foreign_key "feeding_calculations", "brands"
   add_foreign_key "feeding_calculations", "cats"
   add_foreign_key "feeding_calculations", "foods", column: "main_food_id"
   add_foreign_key "feeding_calculations", "foods", column: "sub_food_id"


### PR DESCRIPTION
## 概要
計算ページにメーカー選択のプルダウンを追加

## 実装内容

- [x] feeding_calculationにbrand_idのFKを追加 (`db/migrate/20250108081253_add_brand_to_feeding_calculations.rb`)

- [x] 非同期でメーカーを絞れるようにJavaScriptを追加 (`app/javascript/packs/brand_food_filter.js`)

- [x] 各controller、viewに追記
- [x] ルーティングの追加 (`config/routes.rb`)

 
## 確認方法
Feature/brands searchブランチでデプロイしアプリの動作を確認しました。

## 関連Issue
#66

## 参考資料
- [importmapについて](https://qiita.com/megane42/items/bf85746b9cefaf38f473)
- [member と collectionの使い分け](https://gizanbeak.com/post/rails-member-collection)

## 備考
feeding_calculationsテーブルのbrand_idカラムにnullの値が入っているとデプロイできない問題があったため一旦null:trueにしました。sellが使用できる状態になり次第nullが入ったレコードを削除しnull:falseを設定する