### PR TITLE
Feature/food show

### DIFF
--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,8 +1,8 @@
 class BrandsController < ApplicationController
   def index
     @brand_foods = Brand.joins(:foods)
-                        .order("brands.id ASC")
-                        .pluck("brands.name", "foods.name")
+                        .order("brands.id ASC, foods.id ASC")
+                        .pluck("brands.name", "foods.id", "foods.name")
   end
 
   def foods

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,2 +1,5 @@
 class FoodsController < ApplicationController
+  def show
+    @food = Food.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,8 @@
 module ApplicationHelper
   def safe_external_url(url)
     uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) && !uri.host.nil? ? url : '#'
+    uri.is_a?(URI::HTTP) && !uri.host.nil? ? url : "#"
   rescue URI::InvalidURIError
-    '#'
+    "#"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def safe_external_url(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) && !uri.host.nil? ? url : '#'
+  rescue URI::InvalidURIError
+    '#'
+  end
 end

--- a/app/views/brands/index.html.erb
+++ b/app/views/brands/index.html.erb
@@ -5,8 +5,10 @@
         <%= brand_name %>
       </h2>
       <ul class="list-disc pl-6 text-gray-700">
-        <% foods.each do |_, food_name| %>
-          <li class="py-1"><%= food_name %></li>
+        <% foods.each do |_, food_id, food_name| %>
+          <li class="py-1">
+            <%= link_to food_name, food_path(food_id), class: "text-blue-500 hover:underline" %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,6 +1,8 @@
 <h1>詳細ページ</h1>
-<div class = "food" >
+<div class="food">
   <p><%= @food.brand.name %></p>
   <p><%= @food.name %></p>
-  <p><%= link_to "商品リンク", @food.external_url, class: "text-blue-500 hover:underline" %></p>
+  <p>
+    <%= link_to "商品リンク", safe_external_url(@food.external_url), class: "text-blue-500 hover:underline", target: "_blank", rel: "noopener" %>
+  </p>
 </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,0 +1,5 @@
+<h1>詳細ページ</h1>
+<div class = "food" >
+  <p><%= @food.brand.name %>
+  <p><%= @food.name %>
+</div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,5 +1,6 @@
 <h1>詳細ページ</h1>
 <div class = "food" >
-  <p><%= @food.brand.name %>
-  <p><%= @food.name %>
+  <p><%= @food.brand.name %></p>
+  <p><%= @food.name %></p>
+  <p><a href="<%= @food.external_url %>" style="color: lightblue;">商品リンク</a></p>
 </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -2,5 +2,5 @@
 <div class = "food" >
   <p><%= @food.brand.name %></p>
   <p><%= @food.name %></p>
-  <p><a href="<%= @food.external_url %>" style="color: lightblue;">商品リンク</a></p>
+  <p><%= link_to "商品リンク", @food.external_url, class: "text-blue-500 hover:underline" %></p>
 </div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,5 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-# bundle exec rake db:migrate
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
+bundle exec rake db:migrate
 bundle exec rake db:seed

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,4 +4,5 @@ bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
 bundle exec rake db:migrate
-bundle exec rails db:seed
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
+bundle exec rake db:seed

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,6 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate
+# bundle exec rake db:migrate
 DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
 bundle exec rake db:seed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :foods, only: [ :show ] 
+  resources :foods, only: [ :show ]
   # Defines the root path route ("/")
   # root "posts#index"
   root "feeding_calculation#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
       get :foods # /brands/:id/foods に対応
     end
   end
+
+  resources :foods, only: [ :show ] 
   # Defines the root path route ("/")
   # root "posts#index"
   root "feeding_calculation#new"

--- a/db/foods.csv
+++ b/db/foods.csv
@@ -1,11 +1,11 @@
-,brand_id,name,calories_per_gram,seventy,coefficient,
-,1,インドア(室内で生活する猫専用フード 成猫用),3.74,77.85,0.71,
-,1,インドア ロングヘアー(室内で生活する長毛の猫専用フード 成猫用),3.82,78.37,0.734,
-,2,キャットスマックかつお味,3.3,99.19,0.647,
-,2,キャットスマックまぐろ味,3.3,99.19,0.647,
-,3,プロフェッショナーレ インドア,3.84,70.6,0.71,
-,1,消化器サポートドライ,4.10,76.1,0.73,
-,1,ユリナリーS/Oドライ,3.87,78.13,0.709,
-,1,ユリナリーS/Oオルファクトリードライ,3.86,83.55,0.723,
-,4,プリスクリプション・ダイエット c/dマルチケア チキンドライ,3.89,85.76,0.732,
-,4,プリスクリプション・ダイエット c/dマルチケア コンフォート チキンドライ,3.87,82.22,0.76,
+,brand_id,name,calories_per_gram,seventy,coefficient,external_url
+,1,インドア(室内で生活する猫専用フード 成猫用),3.74,77.85,0.71,"https://shop.royalcanin.jp/%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A2%EF%BC%88%E5%AE%A4%E5%86%85%E3%81%A7%E7%94%9F%E6%B4%BB%E3%81%99%E3%82%8B%E7%8C%AB%E5%B0%82%E7%94%A8%E3%83%95%E3%83%BC%E3%83%89-%E6%88%90%E7%8C%AB%E7%94%A8%EF%BC%89-2529"
+,1,インドア ロングヘアー(室内で生活する長毛の猫専用フード 成猫用),3.82,78.37,0.734,https://shop.royalcanin.jp/%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A2-%E3%83%AD%E3%83%B3%E3%82%B0%E3%83%98%E3%82%A2%E3%83%BC%EF%BC%88%E5%AE%A4%E5%86%85%E3%81%A7%E7%94%9F%E6%B4%BB%E3%81%99%E3%82%8B%E9%95%B7%E6%AF%9B%E3%81%AE%E7%8C%AB%E5%B0%82%E7%94%A8%E3%83%95%E3%83%BC%E3%83%89-%E6%88%90%E7%8C%AB%E7%94%A8%EF%BC%89-2549
+,2,キャットスマックかつお味,3.3,99.19,0.647,https://www.smack.co.jp/cat_food/catsmack_2kg.html#food_01
+,2,キャットスマックまぐろ味,3.3,99.19,0.647,https://www.smack.co.jp/cat_food/catsmack_2kg.html#food_02
+,3,プロフェッショナーレ インドア,3.84,70.6,0.71,https://www.elmo-pet.com/food_lineup/Professionale/Indoor.html
+,1,消化器サポートドライ,4.10,76.1,0.73,https://www.royalcanin.com/jp/cats/products/vet-products/gastrointestinal-3905
+,1,ユリナリーS/Oドライ,3.87,78.13,0.709,https://www.royalcanin.com/jp/cats/products/vet-products/urinary-so-3901
+,1,ユリナリーS/Oオルファクトリードライ,3.86,83.55,0.723,https://www.royalcanin.com/jp/cats/products/vet-products/urinary-so-olfactory-attraction-3944
+,4,プリスクリプション・ダイエット c/dマルチケア チキンドライ,3.89,85.76,0.732,https://www.hills.co.jp/cat-food/pd-cd-multicare-feline-with-chicken-dry?lightboxfired=true
+,4,プリスクリプション・ダイエット c/dマルチケア コンフォート チキンドライ,3.87,82.22,0.76,https://www.hills.co.jp/cat-food/pd-cd-multicare-feline-stress-dry

--- a/db/foods.csv
+++ b/db/foods.csv
@@ -1,5 +1,5 @@
 ,brand_id,name,calories_per_gram,seventy,coefficient,external_url
-,1,インドア(室内で生活する猫専用フード 成猫用),3.74,77.85,0.71,"https://shop.royalcanin.jp/%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A2%EF%BC%88%E5%AE%A4%E5%86%85%E3%81%A7%E7%94%9F%E6%B4%BB%E3%81%99%E3%82%8B%E7%8C%AB%E5%B0%82%E7%94%A8%E3%83%95%E3%83%BC%E3%83%89-%E6%88%90%E7%8C%AB%E7%94%A8%EF%BC%89-2529"
+,1,インドア(室内で生活する猫専用フード 成猫用),3.74,77.85,0.71,https://shop.royalcanin.jp/%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A2%EF%BC%88%E5%AE%A4%E5%86%85%E3%81%A7%E7%94%9F%E6%B4%BB%E3%81%99%E3%82%8B%E7%8C%AB%E5%B0%82%E7%94%A8%E3%83%95%E3%83%BC%E3%83%89-%E6%88%90%E7%8C%AB%E7%94%A8%EF%BC%89-2529
 ,1,インドア ロングヘアー(室内で生活する長毛の猫専用フード 成猫用),3.82,78.37,0.734,https://shop.royalcanin.jp/%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A2-%E3%83%AD%E3%83%B3%E3%82%B0%E3%83%98%E3%82%A2%E3%83%BC%EF%BC%88%E5%AE%A4%E5%86%85%E3%81%A7%E7%94%9F%E6%B4%BB%E3%81%99%E3%82%8B%E9%95%B7%E6%AF%9B%E3%81%AE%E7%8C%AB%E5%B0%82%E7%94%A8%E3%83%95%E3%83%BC%E3%83%89-%E6%88%90%E7%8C%AB%E7%94%A8%EF%BC%89-2549
 ,2,キャットスマックかつお味,3.3,99.19,0.647,https://www.smack.co.jp/cat_food/catsmack_2kg.html#food_01
 ,2,キャットスマックまぐろ味,3.3,99.19,0.647,https://www.smack.co.jp/cat_food/catsmack_2kg.html#food_02

--- a/db/migrate/20250111160053_add_external_url_to_foods.rb
+++ b/db/migrate/20250111160053_add_external_url_to_foods.rb
@@ -1,0 +1,5 @@
+class AddExternalUrlToFoods < ActiveRecord::Migration[7.2]
+  def change
+    add_column :foods, :external_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_08_081253) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_160053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_081253) do
     t.decimal "coefficient"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_url"
     t.index ["brand_id"], name: "index_foods_on_brand_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,5 +21,6 @@ CSV.foreach('db/foods.csv', headers: true) do |row|
     food.calories_per_gram = row['calories_per_gram']
     food.seventy = row['seventy']
     food.coefficient = row['coefficient']
+    food.external_url = row['external_url']
   end
 end


### PR DESCRIPTION
## 概要
フード詳細ページの追加

## 実装内容

- [x] フード一覧ページからフード名をクリックすると詳細ページに遷移する(`config/routes.rb``app/views/brands/index.html.erb``app/views/foods/show.html.erb`)

- [x] `external_url`カラムを追加し各フードの外部リンクを設定 (`db/migrate/20250111160053_add_external_url_to_foods.rb`)

- [x] 商品リンクから各フードの商品ページにリンクする (`app/views/foods/show.html.erb`)
- [x] フード一覧ページでfood_idも昇順に並ぶように設定 (`app/controllers/brands_controller.rb`)

 
## 確認方法
Feature/food showブランチでデプロイしアプリの動作を確認しました。
ローカルでは外部リンクに遷移できるが本番環境だと外部リンクが設定できていません。

## 関連Issue
#108
#30

## 参考資料
- [pluckメソッド](https://qiita.com/k-o-u/items/31e4a2f9f5d2a3c7867f)
- [本番環境のデーターベースをリセットし、seeds.rbを反映させる](https://qiita.com/tatsuya_rfits5/items/c46fdd6f3473d5afc192)

## 備考
sellを導入しseedファイルの再読み込みが必要かもしれません。
