### PR TITLE
Feature/x

### DIFF
--- a/app/views/cats/show.html.erb
+++ b/app/views/cats/show.html.erb
@@ -15,8 +15,11 @@
       </div>
     <% end %>
     
-    <div class="mt-4">
+    <div class="mt-4 flex justify-between items-center">
       <%= link_to '戻る', user_path(@user), class: "px-4 py-2 bg-gray-500 text-white rounded-lg" %>
+      <a href="https://twitter.com/intent/tweet?text=ここにシェアしたいテキストを入れる" target="_blank" class="flex items-center text-blue-500 hover:text-blue-700 transition-colors duration-200">
+        <i class="fa-brands fa-x-twitter text-3xl"></i>
+      </a>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <!-- Material Icons の CDNを追加 -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://use.fontawesome.com/releases/v6.7.2/css/all.css" rel="stylesheet">
   </head>
 
   <body class="flex flex-col min-h-screen">


### PR DESCRIPTION
## 概要
Xシェアボタンを追加

## 実装内容

- [x] fontawesomeのCDNを追加 `(app/views/layouts/application.html.erb)`

- [x] 詳細ページにリンクを追加 `(app/views/cats/show.html.erb)`



 
## 確認方法
Feature/xブランチでデプロイしアプリの動作を確認しました。

## 関連Issue
#105

## 参考資料
- [Twitterシェアボタンは超かんたんに実装できる](https://qiita.com/nakachan1994/items/630616fe0884be62e104)
- [link_toのリンク先を別タブで表示させたい](https://qiita.com/Kazuhiro_Mimaki/items/b3f2d718d2bae9083290)
- [CDNでFont Awesome 6をで利用する](https://qiita.com/day_u/items/cc6dbf7456f122283a96)
