### PR TITLE
Fix/calculation　計算結果表示の修正

### DIFF
--- a/app/controllers/feeding_calculation_controller.rb
+++ b/app/controllers/feeding_calculation_controller.rb
@@ -107,4 +107,17 @@ class FeedingCalculationController < ApplicationController
     flash[:notice] = "給与量の計算結果を保存しました！"
     redirect_to user_path(current_user.id)
   end
+
+  def destroy
+    @calculation_result = current_user.feeding_calculations.find_by(id: params[:id])
+  
+    if @calculation_result
+      @calculation_result.destroy
+      flash[:notice] = "計算結果を削除しました"
+    else
+      flash[:alert] = "削除に失敗しました"
+    end
+  
+    redirect_to user_path(current_user)
+  end
 end

--- a/app/controllers/feeding_calculation_controller.rb
+++ b/app/controllers/feeding_calculation_controller.rb
@@ -110,14 +110,14 @@ class FeedingCalculationController < ApplicationController
 
   def destroy
     @calculation_result = current_user.feeding_calculations.find_by(id: params[:id])
-  
+
     if @calculation_result
       @calculation_result.destroy
       flash[:notice] = "計算結果を削除しました"
     else
       flash[:alert] = "削除に失敗しました"
     end
-  
+
     redirect_to user_path(current_user)
   end
 end

--- a/app/controllers/feeding_calculation_controller.rb
+++ b/app/controllers/feeding_calculation_controller.rb
@@ -91,13 +91,10 @@ class FeedingCalculationController < ApplicationController
       main_rer.round(2)  # メインフードのみ
     end
 
-    # 猫情報を保存
-    cat = current_user.cats.create(weight: weight) # name: cat_name,
-
     # 給与計算結果を保存
     FeedingCalculation.create!(
       user: current_user,
-      cat: cat,
+      weight: weight,
       brand_id: main_brand.id,
       main_food_id: main_food.id,
       brand_id: sub_brand&.id,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @cats = @user.cats
-    @last_calculation = current_user.feeding_calculations.includes(:main_food, :cat).order(created_at: :desc).first
+    @calculation_result = current_user.feeding_calculations.includes(:main_food).order(created_at: :desc)
   end
 
   def edit

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,7 +36,7 @@
     </div>
 
     <div>
-      <%= f.submit t('.sign_up'), class: "w-full py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-lg font-semibold transition" %>
+      <%= f.submit t('.sign_up'), class: "w-full py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-lg font-semibold transition cursor-pointer" %>
     </div>
   <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,7 +26,7 @@
     <% end %>
 
     <div>
-      <%= f.submit t('.sign_in'), class: "w-full py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-lg font-semibold transition" %>
+      <%= f.submit t('.sign_in'), class: "w-full py-2 text-white bg-blue-500 hover:bg-blue-600 rounded-lg font-semibold transition cursor-pointer" %>
     </div>
   <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center text-3xl font-bold mb-10 text-gray-800">ようこそ！</h1>
 
-<div class="relative z-10 flex flex-row justify-center gap-6 w-auto px-5">
+<div class="z-10 flex flex-row justify-center gap-6 w-auto px-5">
   <%# 給与量の計算ボタン %>
   <%= link_to new_feeding_calculation_path, class: "relative card shadow-xl rounded-lg p-6 flex flex-col items-center w-auto transition-all duration-300 hover:scale-105 bg-blue-500 text-white" do %>
     <div class="absolute inset-0 bg-gradient-to-t from-blue-600 to-blue-400 opacity-80 rounded-lg pointer-events-none"></div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center text-3xl font-bold mb-10 text-gray-800">ようこそ！</h1>
 
-<div class="relative z-10 flex flex-row justify-center gap-6 w-full px-5">
+<div class="relative z-10 flex flex-row justify-center gap-6 w-auto px-5">
   <%# 給与量の計算ボタン %>
   <%= link_to new_feeding_calculation_path, class: "relative card shadow-xl rounded-lg p-6 flex flex-col items-center w-auto transition-all duration-300 hover:scale-105 bg-blue-500 text-white" do %>
     <div class="absolute inset-0 bg-gradient-to-t from-blue-600 to-blue-400 opacity-80 rounded-lg pointer-events-none"></div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
 
     <!-- 「猫を登録する」ボタンを中央揃え -->
     <% if @user == current_user %>
-      <div class="mt-4 text-center">
+      <div class="mt-4 text-center pb-6 border-b border-gray-300">
         <%= link_to '猫を登録する', new_user_cat_path(current_user), class: 'px-4 py-2 bg-blue-500 text-2xl text-white rounded-md hover:bg-blue-600 transition-colors duration-200' %>
       </div>
     <% end %>
@@ -38,19 +38,28 @@
 
 
   <% if @user == current_user %>
-    <% if @last_calculation.present? %>
-      <h2 class="text-2xl mb-4 font-semibold text-gray-800">前回の計算結果</h2>
-      <div class="bg-white shadow-md rounded-lg p-6 flex flex-col items-center w-full max-w-2xl mx-4 mb-6">
-        <p class="text-lg mb-2">前回選択したメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.main_brand.name %></span></p>
-        <p class="text-lg mb-2">前回選択したフード: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food.name %></span></p>
-        <p class="text-lg mb-2">前回選択したサブメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_brand&.name %></span></p>
-        <p class="text-lg mb-2">前回選択したサブフード: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food&.name %></span></p>
-        <p class="text-lg mb-2">体重: <span class="font-semibold text-gray-900"><%= @last_calculation.weight %></span> kg</p>
-        <p class="text-lg mb-2">メインフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food_amount %></span> g</p>
-        <p class="text-lg mb-2">サブフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food_amount %></span> g</p>
-        <p class="text-lg mb-2">合計カロリー: <span class="font-semibold text-gray-900"><%= @last_calculation.total_daily_calories %></span> kcal</p>
-        <p class="text-sm text-gray-500 mt-4">作成日時: <%= @last_calculation.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+    <% if @calculation_result.present? %>
+      <h2 class="text-2xl mb-4 font-semibold text-gray-800">計算結果一覧</h2>
+      <% @calculation_result.each do |calculation| %>
+        <div class="bg-white shadow-md rounded-lg p-6 flex flex-col items-center w-full max-w-2xl mx-4 mb-6">
+        <div class="grid grid-cols-1 gap-4">
+        <p class="text-lg"><span class="font-semibold text-gray-900">メーカー:</span> <%= calculation.main_brand.name %></p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">フード:</span> <%= calculation.main_food.name %></p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">サブメーカー:</span> <%= calculation.sub_brand&.name.presence || 'なし' %></p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">サブフード:</span> <%= calculation.sub_food&.name.presence || 'なし' %></p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">体重:</span> <%= calculation.weight %> kg</p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">メインフードの量:</span> <%= calculation.main_food_amount %> g</p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">サブフードの量:</span> <%= calculation.sub_food_amount %> g</p>
+        <p class="text-lg"><span class="font-semibold text-gray-900">合計カロリー:</span> <%= calculation.total_daily_calories %> kcal</p>
       </div>
+      <p class="text-sm text-gray-500 mt-4 text-right">作成日時: <%= calculation.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+
+      <div class="flex justify-center mt-4">
+        <%= button_to '削除', feeding_calculation_path(calculation.id), method: :delete, 
+              class: 'bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-6 rounded-lg shadow' %>
+      </div>
+        </div>
+      <% end %>
     <% else %>
       <p class="bg-white shadow-md text-red-500 p-4 rounded-md mt-4 w-full max-w-3xl mx-auto text-center">
         計算結果はまだありません。

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,28 +29,32 @@
     </div>
 
     <!-- 「猫を登録する」ボタンを中央揃え -->
-    <div class="mt-4 text-center">
-      <%= link_to '猫を登録する', new_user_cat_path(current_user), class: 'px-4 py-2 bg-blue-500 text-2xl text-white rounded-md hover:bg-blue-600 transition-colors duration-200' %>
-    </div>
+    <% if @user == current_user %>
+      <div class="mt-4 text-center">
+        <%= link_to '猫を登録する', new_user_cat_path(current_user), class: 'px-4 py-2 bg-blue-500 text-2xl text-white rounded-md hover:bg-blue-600 transition-colors duration-200' %>
+      </div>
+    <% end %>
   </div>
 
-  <h2 class="text-2xl mb-4 font-semibold text-gray-800">前回の計算結果</h2>
 
-  <% if @last_calculation.present? %>
-    <div class="bg-white shadow-md rounded-lg p-6 flex flex-col items-center w-full max-w-2xl mx-4 mb-6">
-      <p class="text-lg mb-2">前回選択したメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.main_brand.name %></span></p>
-      <p class="text-lg mb-2">前回選択したフード: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food.name %></span></p>
-      <p class="text-lg mb-2">前回選択したサブメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_brand&.name %></span></p>
-      <p class="text-lg mb-2">前回選択したサブフード: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food&.name %></span></p>
-      <p class="text-lg mb-2">体重: <span class="font-semibold text-gray-900"><%= @last_calculation.weight %></span> kg</p>
-      <p class="text-lg mb-2">メインフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food_amount %></span> g</p>
-      <p class="text-lg mb-2">サブフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food_amount %></span> g</p>
-      <p class="text-lg mb-2">合計カロリー: <span class="font-semibold text-gray-900"><%= @last_calculation.total_daily_calories %></span> kcal</p>
-      <p class="text-sm text-gray-500 mt-4">作成日時: <%= @last_calculation.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
-    </div>
-  <% else %>
-    <p class="bg-white shadow-md text-red-500 p-4 rounded-md mt-4 w-full max-w-3xl mx-auto text-center">
-      計算結果はまだありません。
-    </p>
+  <% if @user == current_user %>
+    <% if @last_calculation.present? %>
+      <h2 class="text-2xl mb-4 font-semibold text-gray-800">前回の計算結果</h2>
+      <div class="bg-white shadow-md rounded-lg p-6 flex flex-col items-center w-full max-w-2xl mx-4 mb-6">
+        <p class="text-lg mb-2">前回選択したメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.main_brand.name %></span></p>
+        <p class="text-lg mb-2">前回選択したフード: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food.name %></span></p>
+        <p class="text-lg mb-2">前回選択したサブメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_brand&.name %></span></p>
+        <p class="text-lg mb-2">前回選択したサブフード: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food&.name %></span></p>
+        <p class="text-lg mb-2">体重: <span class="font-semibold text-gray-900"><%= @last_calculation.weight %></span> kg</p>
+        <p class="text-lg mb-2">メインフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food_amount %></span> g</p>
+        <p class="text-lg mb-2">サブフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food_amount %></span> g</p>
+        <p class="text-lg mb-2">合計カロリー: <span class="font-semibold text-gray-900"><%= @last_calculation.total_daily_calories %></span> kcal</p>
+        <p class="text-sm text-gray-500 mt-4">作成日時: <%= @last_calculation.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+      </div>
+    <% else %>
+      <p class="bg-white shadow-md text-red-500 p-4 rounded-md mt-4 w-full max-w-3xl mx-auto text-center">
+        計算結果はまだありません。
+      </p>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,7 +42,7 @@
       <p class="text-lg mb-2">前回選択したフード: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food.name %></span></p>
       <p class="text-lg mb-2">前回選択したサブメーカー: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_brand&.name %></span></p>
       <p class="text-lg mb-2">前回選択したサブフード: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food&.name %></span></p>
-      <p class="text-lg mb-2">体重: <span class="font-semibold text-gray-900"><%= @last_calculation.cat.weight %></span> kg</p>
+      <p class="text-lg mb-2">体重: <span class="font-semibold text-gray-900"><%= @last_calculation.weight %></span> kg</p>
       <p class="text-lg mb-2">メインフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.main_food_amount %></span> g</p>
       <p class="text-lg mb-2">サブフードの量: <span class="font-semibold text-gray-900"><%= @last_calculation.sub_food_amount %></span> g</p>
       <p class="text-lg mb-2">合計カロリー: <span class="font-semibold text-gray-900"><%= @last_calculation.total_daily_calories %></span> kcal</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
       post :save      # 結果を保存 (ログインユーザーのみ)
       get :calculate
     end
+    member do
+      delete :destroy
+    end
   end
 
   resources :brands, only: [ :index, :show ] do

--- a/db/migrate/20250308013308_remove_cat_id_from_feeding_calculations.rb
+++ b/db/migrate/20250308013308_remove_cat_id_from_feeding_calculations.rb
@@ -1,0 +1,5 @@
+class RemoveCatIdFromFeedingCalculations < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :feeding_calculations, :cat_id, :bigint
+  end
+end

--- a/db/migrate/20250308013849_add_weight_to_feeding_calculations.rb
+++ b/db/migrate/20250308013849_add_weight_to_feeding_calculations.rb
@@ -1,0 +1,5 @@
+class AddWeightToFeedingCalculations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :feeding_calculations, :weight, :decimal, precision: 3, scale: 1, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_10_162124) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_08_013849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,7 +78,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_10_162124) do
   end
 
   create_table "feeding_calculations", force: :cascade do |t|
-    t.bigint "cat_id", null: false
     t.bigint "main_food_id"
     t.bigint "sub_food_id"
     t.decimal "main_food_amount"
@@ -88,8 +87,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_10_162124) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.bigint "brand_id"
+    t.decimal "weight", precision: 3, scale: 1
     t.index ["brand_id"], name: "index_feeding_calculations_on_brand_id"
-    t.index ["cat_id"], name: "index_feeding_calculations_on_cat_id"
     t.index ["main_food_id"], name: "index_feeding_calculations_on_main_food_id"
     t.index ["sub_food_id"], name: "index_feeding_calculations_on_sub_food_id"
     t.index ["user_id"], name: "index_feeding_calculations_on_user_id"
@@ -150,7 +149,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_10_162124) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "cats", "users"
   add_foreign_key "feeding_calculations", "brands"
-  add_foreign_key "feeding_calculations", "cats"
   add_foreign_key "feeding_calculations", "foods", column: "main_food_id"
   add_foreign_key "feeding_calculations", "foods", column: "sub_food_id"
   add_foreign_key "feeding_calculations", "users"


### PR DESCRIPTION
## 概要
- 計算結果を複数保存できるように変更しました。また、過去の計算結果を削除できるようにしました。
- 自分のユーザーページにしかcalculation_resultと「猫を登録」ボタンが表示されないようにしました。

## 実装内容

- [x] destroyメソッドを追加`(app/controllers/feeding_calculation_controller.rb)`
- [x] ルーティングにdestroyを追加`(config/routes.rb)`

- [x] 変数名の変更 `(app/controllers/users_controller.rb)`
- [x] 自分のみcalculation_resultと「猫を登録」ボタンが表示される`(app/views/users/show.html.erb)`
- [x] feeding_calculationテーブルからcat_idを削除、feeding_calculationにweightカラムを追加

- [x] ポインターが表示されるように微調整`(app/views/devise/registrations/new.html.erb)(app/views/devise/sessions/new.html.erb)`
- [x] メニューが選べない問題を解消`(app/views/home/index.html.erb)`



 
## 確認方法
Fix/calculationブランチでデプロイしアプリの動作を確認しました。

## 関連Issue


## 参考資料

