### PR TITLE
add:bookmark_rspec ブックマーク機能のRSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "aws-sdk-s3", require: false
 
 gem "rspec-rails", "~> 7.0.0"
 gem "factory_bot_rails"
+gem "faker"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -410,6 +412,7 @@ DEPENDENCIES
   devise-i18n-views
   dotenv-rails
   factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   jsbundling-rails

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bookmark do
+    association :user
+    association :food
+  end
+end

--- a/spec/factories/brands.rb
+++ b/spec/factories/brands.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :brand do
+    name { "ブランドA" }
+  end
+end

--- a/spec/factories/foods.rb
+++ b/spec/factories/foods.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :food do
+    name { "キャットフードA" }
+    association :brand # brand を関連付ける
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "テストユーザー" }
+    email { Faker::Internet.email }
+    password { "password123" }
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,5 +1,36 @@
 require 'rails_helper'
+require 'faker'
 
 RSpec.describe Bookmark, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:food) { create(:food) } # Food は自動で Brand に関連付けされる
+  let(:bookmark) { build(:bookmark, user: user, food: food) }
+
+  describe "バリデーションのテスト" do
+    it "有効なBookmarkの場合は保存できる" do
+      expect(bookmark).to be_valid
+    end
+
+    it "userがない場合は無効" do
+      bookmark.user = nil
+      expect(bookmark).to be_invalid
+      expect(bookmark.errors[:user]).to include("を入力してください")
+    end
+
+    it "foodがない場合は無効" do
+      bookmark.food = nil
+      expect(bookmark).to be_invalid
+      expect(bookmark.errors[:food]).to include("を入力してください")
+    end
+  end
+
+  describe "関連付けのテスト" do
+    it "User に属している" do
+      expect(Bookmark.reflect_on_association(:user).macro).to eq(:belongs_to)
+    end
+
+    it "Food に属している" do
+      expect(Bookmark.reflect_on_association(:food).macro).to eq(:belongs_to)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 概要
ブックマーク機能のRSpecの設定

## 実装内容

- [x] gem fakerを導入`(Gemfile)`

- [x] `user`と`food`を`FactoryBot`で作成し`bookmark`を生成。`(spec/factories/bookmarks.rb)、(spec/factories/brands.rb)、(spec/factories/foods.rb)、(spec/factories/users.rb)`

- [x] テスト内容を記載`(spec/models/bookmark_spec.rb)`

 
## 確認方法
テストが通ることを確認

<img width="563" alt="スクリーンショット 2025-03-12 16 36 54" src="https://github.com/user-attachments/assets/fcf31913-4ead-4649-8a90-d1b83519fbbc" />

## 関連Issue
#76

## 参考資料

