### PR TITLE
add:feeding_calculation_rspec feeding_calculationモデルのRSpec

### DIFF
--- a/app/models/feeding_calculation.rb
+++ b/app/models/feeding_calculation.rb
@@ -1,6 +1,5 @@
 class FeedingCalculation < ApplicationRecord
   belongs_to :user, optional: true # 未ログイン時はユーザーがいないため optional: true
-  belongs_to :cat, optional: true # 未ログイン時は猫の情報を保存しないため optional: true
   belongs_to :brand, optional: true
   belongs_to :main_food, class_name: "Food", foreign_key: "main_food_id", optional: true
   belongs_to :sub_food, class_name: "Food", foreign_key: "sub_food_id", optional: true

--- a/spec/factories/feeding_calculations.rb
+++ b/spec/factories/feeding_calculations.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :feeding_calculation do
+    association :user, factory: :user
+    association :brand, factory: :brand
+    association :main_food, factory: :food
+    association :sub_food, factory: :food
+  end
+end

--- a/spec/models/feeding_calculation_spec.rb
+++ b/spec/models/feeding_calculation_spec.rb
@@ -1,5 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe FeedingCalculation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "関連付けのテスト" do
+    it "User に属している（optional: true）" do
+      expect(FeedingCalculation.reflect_on_association(:user).macro).to eq(:belongs_to)
+      expect(FeedingCalculation.reflect_on_association(:user).options[:optional]).to eq(true)
+    end
+
+    it "Brand に属している（optional: true）" do
+      expect(FeedingCalculation.reflect_on_association(:brand).macro).to eq(:belongs_to)
+      expect(FeedingCalculation.reflect_on_association(:brand).options[:optional]).to eq(true)
+    end
+
+    it "MainFood（Foodモデル） に属している（optional: true）" do
+      assoc = FeedingCalculation.reflect_on_association(:main_food)
+      expect(assoc.macro).to eq(:belongs_to)
+      expect(assoc.options[:class_name]).to eq("Food")
+      expect(assoc.options[:foreign_key]).to eq("main_food_id")
+      expect(assoc.options[:optional]).to eq(true)
+    end
+
+    it "SubFood（Foodモデル） に属している（optional: true）" do
+      assoc = FeedingCalculation.reflect_on_association(:sub_food)
+      expect(assoc.macro).to eq(:belongs_to)
+      expect(assoc.options[:class_name]).to eq("Food")
+      expect(assoc.options[:foreign_key]).to eq("sub_food_id")
+      expect(assoc.options[:optional]).to eq(true)
+    end
+  end
+
+  describe "インスタンスメソッドのテスト" do
+    let(:brand1) { create(:brand) }
+    let(:brand2) { create(:brand) }
+    let(:main_food) { create(:food, brand: brand1) }
+    let(:sub_food) { create(:food, brand: brand2) }
+    let(:feeding_calculation) { create(:feeding_calculation, main_food: main_food, sub_food: sub_food) }
+
+    describe "#main_brand" do
+      it "main_food が存在する場合、brand を返す" do
+        expect(feeding_calculation.main_brand).to eq(brand1)
+      end
+
+      it "main_food が存在しない場合、nil を返す" do
+        feeding_calculation.main_food = nil
+        expect(feeding_calculation.main_brand).to be_nil
+      end
+    end
+
+    describe "#sub_brand" do
+      it "sub_food が存在する場合、brand を返す" do
+        expect(feeding_calculation.sub_brand).to eq(brand2)
+      end
+
+      it "sub_food が存在しない場合、nil を返す" do
+        feeding_calculation.sub_food = nil
+        expect(feeding_calculation.sub_brand).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
feeding_calculationモデルのRSpeccを記載

## 実装内容

- [x] feeding_calculationのFactoryBotを追加`(spec/factories/feeding_calculations.rb)`
- [x] モデルの修正`(app/models/feeding_calculation.rb)`

- [x] テスト内容を記載`(spec/models/feeding_calculation_spec.rb)`



 
## 確認方法
テストが通ることを確認

<img width="560" alt="スクリーンショット 2025-03-12 18 04 31" src="https://github.com/user-attachments/assets/86effdec-471d-4edf-9ba3-ff143686f6bf" />

## 関連Issue
#75

## 参考資料

