### PR TITLE
Fix/calculation_layouts 計算ページのレスポンシブ対応

### DIFF
--- a/app/views/feeding_calculation/new.html.erb
+++ b/app/views/feeding_calculation/new.html.erb
@@ -1,5 +1,5 @@
-<h2 class="text-center mb-6 text-2xl font-semibold">1日の給与量を計算する</h2>
-<div class="flex justify-center mb-4">
+<h2 class="text-center mb-4 mt-2 text-2xl text-default font-semibold">1日の給与量を計算する</h2>
+<div class="flex justify-center mb-4 mx-2 text-default">
   <%= form_with url: calculate_feeding_calculation_index_path, method: :post, local: true, data: { turbo: false }, class: "flex flex-col items-center max-w-lg w-full bg-white p-6 rounded-lg shadow-lg" do |form| %>
     
     <!-- メインフードのメーカー -->
@@ -8,7 +8,7 @@
       <%= select_tag :main_brand_id, options_from_collection_for_select(Brand.all, :id, :name),
         prompt: "メーカーを選択",
         id: "main_brand_select",
-        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400" %>
+        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400 text-gray-600" %>
     </div>
 
     <!-- メインフード -->
@@ -18,7 +18,7 @@
         prompt: "フードを選択",
         id: "main_food_select",
         name: "main_food_id",
-        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400" %>
+        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400 text-gray-600" %>
     </div>
 
     <!-- サブフードのメーカー (任意) -->
@@ -27,7 +27,7 @@
       <%= select_tag :sub_brand_id, options_from_collection_for_select(Brand.all, :id, :name),
         prompt: "メーカーを選択",
         id: "sub_brand_select",
-        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400" %>
+        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400 text-gray-600" %>
     </div>
 
     <!-- サブフード (任意) -->
@@ -37,20 +37,20 @@
         prompt: "フードを選択",
         id: "sub_food_select",
         name: "sub_food_id",
-        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400" %>
+        class: "border p-3 rounded-md w-full focus:ring-2 focus:ring-blue-400 text-gray-600" %>
     </div>
 
     <!-- 体重 -->
     <div class="text-xl mb-6 w-full flex items-center">
       <%= form.label :weight, "体重", class: "font-medium mr-3" %>
       <%= form.text_field :weight, value: nil, placeholder: "例: 4.8", required: true,
-        class: "border p-3 rounded-md w-24 focus:ring-2 focus:ring-blue-400", 
+        class: "border p-3 rounded-md w-24 focus:ring-2 focus:ring-blue-400 text-gray-600", 
         oninput: "this.value = this.value.replace(/[０-９]/g, function(s) { return String.fromCharCode(s.charCodeAt(0) - 0xFEE0); });" %>
-      <span class="ml-2 text-gray-600">kg</span>
+      <span class="ml-2">kg</span>
     </div>
 
     <!-- 送信ボタン -->
-    <button type="submit" class="w-full py-3 text-lg bg-pink-200 text-orange-700 rounded-md hover:bg-pink-300 transition">
+    <button type="submit" class="font-semibold w-full py-3 text-lg bg-pink-200 rounded-md hover:bg-pink-300 transition">
       計算する
     </button>
 

--- a/app/views/feeding_calculation/result.html.erb
+++ b/app/views/feeding_calculation/result.html.erb
@@ -2,7 +2,7 @@
 
 <!-- 計算結果の表示 -->
 <div class="flex justify-center mb-12">
-  <div class="bg-white p-6 rounded-lg shadow-md max-w-sm w-full">
+  <div class="bg-white p-6 rounded-lg shadow-md max-w-sm w-full mx-2">
     <div class="space-y-4">
       <div class="flex flex-col">
         <span class="text-sm text-gray-600">メインフード メーカー名</span>
@@ -53,7 +53,7 @@
 </div>
 
 <!-- ボタンエリア -->
-<div class="flex flex-col items-center space-y-4 max-w-sm mx-auto mb-4">
+<div class="flex flex-col items-center space-y-4 px-2 max-w-sm mx-auto mb-4">
   <%= form_with url: save_feeding_calculation_index_path, method: :post, local: true, class: "w-full" do |f| %>
     <%= hidden_field_tag :main_brand_id, @result[:main_brand_id] %>
     <%= hidden_field_tag :main_food_id, @result[:main_food_id] %>

--- a/app/views/feeding_calculation/result.html.erb
+++ b/app/views/feeding_calculation/result.html.erb
@@ -1,4 +1,4 @@
-<h2 class="text-center mb-6 text-2xl font-semibold">計算結果</h2>
+<h2 class="text-center mb-4 mt-2 text-2xl font-semibold text-default">計算結果</h2>
 
 <!-- 計算結果の表示 -->
 <div class="flex justify-center mb-12">
@@ -53,7 +53,7 @@
 </div>
 
 <!-- ボタンエリア -->
-<div class="flex flex-col items-center space-y-4 px-2 max-w-sm mx-auto mb-4">
+<div class="flex flex-col items-center space-y-4 px-2 max-w-sm mx-auto mb-4 text-default">
   <%= form_with url: save_feeding_calculation_index_path, method: :post, local: true, class: "w-full" do |f| %>
     <%= hidden_field_tag :main_brand_id, @result[:main_brand_id] %>
     <%= hidden_field_tag :main_food_id, @result[:main_food_id] %>
@@ -62,10 +62,10 @@
       <%= hidden_field_tag :sub_brand_id, @result[:sub_brand_id] %>
       <%= hidden_field_tag :sub_food_id, @result[:sub_food_id] %>
     <% end %>
-    <button type="submit" class="w-full py-3 bg-pink-200 text-orange-700 rounded-md text-lg font-semibold hover:bg-pink-300 transition">
+    <button type="submit" class="w-full py-3 bg-pink-200 rounded-md text-lg font-semibold hover:bg-pink-300 transition">
       マイページに保存する
     </button>
   <% end %>
 
-  <%= link_to "再計算する", new_feeding_calculation_path, class: "w-full py-3 bg-emerald-200 text-orange-700 rounded-md text-lg font-semibold text-center hover:bg-emerald-300 transition" %>
+  <%= link_to "再計算する", new_feeding_calculation_path, class: "w-full py-3 bg-emerald-200 rounded-md text-lg font-semibold text-center hover:bg-emerald-300 transition" %>
 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -37,8 +37,6 @@
         });
       }
     });
-
-    document.addEventListener("turbo:load", initializeStarRating);
   </script>
 
   <div class="mb-4">

--- a/app/views/shared/_cat_card.html.erb
+++ b/app/views/shared/_cat_card.html.erb
@@ -3,14 +3,16 @@
     <%= image_tag(cat.cat_profile.attached? ? cat.cat_profile : 'pets.png', class: "w-full h-full object-cover") %>
   </div>
   <div class="p-4 card-content w-full max-w-xs mx-auto">
-    <div class="flex items-center">
+    <div class="flex items-lfet">
       <% user = cat.user %>
       <%= link_to image_tag(user.profile.attached? ? user.profile : 'account.png', class: 'w-10 h-10 rounded-full object-cover border border-gray-300 mr-3'), user_path(user) %>
       <%= link_to user.name, user_path(user), class: 'text-lg font-semibold text-gray-800' %>
     </div>
-    <h2 class="text-xl font-semibold text-gray-900 truncate" title="<%= cat.name %>"><%= cat.name %></h2>
-    <p class="text-l truncate" title="<%= cat.cat_introduction %>"><%= cat.cat_introduction %></p>
-    <p class="text-sm text-gray-500">登録日: <%= cat.created_at.strftime('%Y-%m-%d') %></p>
+    <div class="text-left my-2">
+      <h2 class="text-xl font-semibold text-gray-900 truncate" title="<%= cat.name %>"><%= cat.name %></h2>
+      <p class="text-l truncate" title="<%= cat.cat_introduction %>"><%= cat.cat_introduction %></p>
+      <p class="text-sm text-gray-500">登録日: <%= cat.created_at.strftime('%Y-%m-%d') %></p>
+    </div>
     <%= link_to '詳細', user_cat_path(user, cat), class: 'btn btn-sm md:btn-md bg-green-500 hover:bg-green-600 hover:text-gray-500' %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,9 @@
 <div class="flex flex-col items-center">
-  <h1 class="text-3xl font-bold mb-6 text-center text-gray-800">ユーザーページ</h1>
+  <h1 class="text-3xl font-bold mb-6 mt-2 text-center text-gray-800">ユーザーページ</h1>
 
   <!-- コンテンツを中央に配置 -->
-  <div class="w-full rounded-lg p-6 mb-6 mx-auto text-center">
-    <div class="bg-white w-[300px] p-5 text-center mx-auto">
+  <div class="w-full rounded-lg p-6 sm:mb-2 mx-auto text-center">
+    <div class="bg-white w-[300px] p-5 mb-6 text-center mx-auto">
       <%= image_tag @user.profile.attached? ? @user.profile : 'account.png', class: 'w-14 h-14 rounded-full object-cover border border-300 mx-auto' %>
       <div class="font-bold">
         <p class="text-2xl"><%= @user.name %></p>
@@ -34,36 +34,79 @@
         <%= link_to 'ペットを登録する', new_user_cat_path(current_user), class: 'px-4 py-2 bg-blue-500 text-2xl text-white rounded-md hover:bg-blue-600 transition-colors duration-200' %>
       </div>
     <% end %>
-  </div>
+  
 
 
-  <% if @user == current_user %>
-    <% if @calculation_result.present? %>
-      <h2 class="text-2xl mb-4 font-semibold text-gray-800">計算結果一覧</h2>
-      <% @calculation_result.each do |calculation| %>
-        <div class="bg-white shadow-md rounded-lg p-6 flex flex-col items-center w-full max-w-2xl mx-4 mb-6">
-        <div class="grid grid-cols-1 gap-4">
-        <p class="text-lg"><span class="font-semibold text-gray-900">メーカー:</span> <%= calculation.main_brand.name %></p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">フード:</span> <%= calculation.main_food.name %></p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">サブメーカー:</span> <%= calculation.sub_brand&.name.presence || 'なし' %></p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">サブフード:</span> <%= calculation.sub_food&.name.presence || 'なし' %></p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">体重:</span> <%= calculation.weight %> kg</p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">メインフードの量:</span> <%= calculation.main_food_amount %> g</p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">サブフードの量:</span> <%= calculation.sub_food_amount %> g</p>
-        <p class="text-lg"><span class="font-semibold text-gray-900">合計カロリー:</span> <%= calculation.total_daily_calories %> kcal</p>
-      </div>
-      <p class="text-sm text-gray-500 mt-4 text-right">作成日時: <%= calculation.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
-
-      <div class="flex justify-center mt-4">
-        <%= button_to '削除', feeding_calculation_path(calculation.id), method: :delete, 
-              class: 'bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-6 rounded-lg shadow' %>
-      </div>
+    <% if @user == current_user %>
+      <% if @calculation_result.present? %>
+        <h2 class="text-2xl mb-4 font-semibold text-gray-800">計算結果一覧</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-6">
+          <% @calculation_result.each do |calculation| %>
+            <div class="bg-white content w-full mx-auto p-6 rounded-lg shadow-md">
+              <div class="text-left space-y-1">
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">メインフード メーカー名</span>
+                  <strong class="text-lg text-gray-900"><%= calculation.main_brand.name %></strong>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">メインフード フード名</span>
+                  <strong class="text-lg text-gray-900"><%= calculation.main_food.name %></strong>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">サブフード メーカー名</span>
+                  <strong class="text-lg text-gray-900"><%= calculation.sub_brand&.name.presence || 'なし' %></strong>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">サブフード フード名</span>
+                  <strong class="text-lg text-gray-900"><%= calculation.sub_food&.name.presence || 'なし' %></strong>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">体重</span>
+                  <div class="flex items-center text-lg text-gray-900">
+                    <strong><%= calculation.weight %></strong>
+                    <span class="ml-1 text-sm text-gray-600">kg</span>
+                  </div>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">メインフードの1日の必要給与量</span>
+                  <div class="flex items-center text-lg text-gray-900">
+                    <strong><%= calculation.main_food_amount %></strong>
+                    <span class="ml-1 text-sm text-gray-600">g</span>
+                  </div>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">サブフードの1日の必要給与量</span>
+                  <div class="flex items-center text-lg text-gray-900">
+                    <strong><%= calculation.sub_food_amount %></strong>
+                    <span class="ml-1 text-sm text-gray-600">g</span>
+                  </div>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">必要エネルギー要求量 (RER)</span>
+                  <div class="flex items-center text-lg text-gray-900">
+                    <strong><%= calculation.total_daily_calories %></strong>
+                    <span class="ml-1 text-sm text-gray-600">kcal</span>
+                  </div>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-sm text-gray-600">作成日</span>
+                  <div class="flex items-center text-lg text-gray-900">
+                    <strong><%= calculation.created_at.strftime('%Y-%m-%d') %></strong>
+                  </div>
+                </div>
+                <div class="flex justify-center mt-4">
+                  <%= button_to '削除', feeding_calculation_path(calculation.id), method: :delete, 
+                        class: 'bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-6 rounded-lg shadow' %>
+                </div>
+              </div>
+            </div>
+          <% end %>
         </div>
+      <% else %>
+        <p class="bg-white shadow-md text-red-500 p-4 rounded-md mt-4 w-full max-w-3xl mx-auto text-center">
+          計算結果はまだありません。
+        </p>
       <% end %>
-    <% else %>
-      <p class="bg-white shadow-md text-red-500 p-4 rounded-md mt-4 w-full max-w-3xl mx-auto text-center">
-        計算結果はまだありません。
-      </p>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     extend: {
       colors: {
         'custom-orange': '#e07f34',
+        'default': '#8b4513',
       },
       fontFamily: {
         'zen': ['ZenMaruGothic', 'sans-serif'], // ここに追加


### PR DESCRIPTION
## 概要
計算ページのレスポンシブ対応をしました。

## 実装内容

- [x] テキストのカラーを変更`(app/views/feeding_calculation/new.html.erb)、(app/views/feeding_calculation/result.html.erb)`

- [x] 不要な記述を削除`(app/views/reviews/new.html.erb)`

- [x] 配置を修正`(app/views/shared/_cat_card.html.erb)`
- [x] カードのサイズを整え、画面サイズごとに並ぶ枚数が変わるようにレスポンシブに対応させました`(app/views/users/show.html.erb)`
- [x] defaultのカラーを設定`(tailwind.config.js)`

 
## 確認方法
Fix/calculation_layoutsブランチでデプロイしアプリの動作を確認しました。

## 関連Issue
- close #86 
- close #88

## 参考資料
- [tailwindcssでカラーパレットをカスタマイズする方法](https://www.luku.work/tailwindcss-customize-color/)
- [tailwindColors](https://tailwindcss.com/docs/colors)
