### PR TITLE
Fix/material_icon マテリアルアイコンの修正

### DIFF
--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -19,7 +19,7 @@
     <div class="flex justify-between my-6">
       <div class="flex-1 flex justify-center">
         <%= link_to safe_external_url(@food.external_url), class: "flex items-center text-blue-500 text-lg", target: "_blank", rel: "noopener" do %>
-          <span class="material-icons">link</span>
+          <span class="material-icons">open_in_new</span>
           <p class="hover:underline">商品ページはこちら</p>
         <% end %>
       </div>


### PR DESCRIPTION
## 概要
food/showページの外部リンクアイコンを修正

## 実装内容

- [x] マテリアルアイコンを`link`から`open_in_new`に変更`(app/views/foods/show.html.erb)`


 
## 確認方法
Fix/material_iconブランチでデプロイしアプリの動作を確認しました。

## 関連Issue


## 参考資料

