### PR TITLE
Fix/create user 作成者のみに権限付与

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -1,6 +1,6 @@
 class CatsController < ApplicationController
-  before_action :set_cat, only: [:edit, :update, :destroy]
-  before_action :authorize_user, only: [:edit, :update, :destroy]
+  before_action :set_cat, only: [ :edit, :update, :destroy ]
+  before_action :authorize_user, only: [ :edit, :update, :destroy ]
 
   helper_method :prepare_meta_tags
 
@@ -55,7 +55,7 @@ class CatsController < ApplicationController
 
   private
 
-  
+
 
   def set_cat
     @cat = Cat.find(params[:id])

--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -1,13 +1,16 @@
 class CatsController < ApplicationController
-  before_action :set_user
-  before_action :set_user, except: [ :index ]
+  before_action :set_cat, only: [:edit, :update, :destroy]
+  before_action :authorize_user, only: [:edit, :update, :destroy]
+
   helper_method :prepare_meta_tags
 
   def new
+    @user = User.find(params[:user_id])
     @cat = @user.cats.build
   end
 
   def create
+    @user = User.find(params[:user_id])
     @cat = @user.cats.build(cat_params)
     if @cat.save
       redirect_to cats_path, notice: "猫が登録されました"
@@ -24,19 +27,17 @@ class CatsController < ApplicationController
     @cat = Cat.find(params[:id])
     prepare_meta_tags(@cat)
 
-    # 一覧ページ (/cats) から遷移した場合のみ、session に保存
     if request.referer&.include?(cats_path)
       session[:return_to] = request.referer
     end
   end
 
   def edit
-    @cat = Cat.find(params[:id])
+    @user = User.find(params[:user_id])
+    # 編集処理
   end
 
   def update
-    @cat = Cat.find(params[:id])
-
     if @cat.update(cat_params)
       redirect_to cats_path, notice: "情報が更新されました"
     else
@@ -46,17 +47,25 @@ class CatsController < ApplicationController
   end
 
   def destroy
-    @cat = Cat.find(params[:id]) # まずは@catを見つける
-    @user = @cat.user # @catから@userを取得する
-    @cat.destroy! # その後に削除する
+    @user = @cat.user # 作成者の取得
+    @cat.destroy!
     flash[:notice] = "削除しました"
     redirect_to user_path(@user)
   end
 
   private
 
-  def set_user
-    @user = User.find(params[:user_id])
+  
+
+  def set_cat
+    @cat = Cat.find(params[:id])
+  end
+
+  def authorize_user
+    # 作成者でない場合、アクセス拒否
+    unless @cat.user == current_user
+      redirect_to cats_path, alert: "権限がありません"
+    end
   end
 
   def cat_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authorize_user, only: [:edit, :update]
+  before_action :authorize_user, only: [ :edit, :update ]
   def show
     @user = User.find(params[:id])
     @cats = @user.cats.order(created_at: :desc)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authorize_user, only: [:edit, :update]
   def show
     @user = User.find(params[:id])
     @cats = @user.cats.order(created_at: :desc)
@@ -28,5 +29,12 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :self_introduction, :profile)
+  end
+
+  def authorize_user
+    @user = User.find(params[:id])
+    unless @user == current_user
+      redirect_to user_path, alert: "権限がありません"
+    end
   end
 end


### PR DESCRIPTION
## 概要
edit、update、destroyアクションを作成者のみが行えるように修正

## 実装内容

- [x] 作成者の確認をする記述を追加`(app/controllers/cats_controller.rb、app/controllers/users_controller.rb)`
```ruby
def authorize_user
    # 作成者でない場合、アクセス拒否
    unless @cat.user == current_user
      redirect_to cats_path, alert: "権限がありません"
    end
end
```

- [x] アクション前に`authorize_user`の実行`(app/controllers/cats_controller.rb、app/controllers/users_controller.rb)`

```ruby
before_action :authorize_user, only: [ :edit, :update, :destroy ]
```

 
## 確認方法
ブランチでデプロイしアプリの動作を確認しました。

## 関連Issue


## 参考資料

